### PR TITLE
New reset added for SupervisorEmitterReceiver

### DIFF
--- a/deepbots/supervisor/controllers/supervisor_emitter_receiver.py
+++ b/deepbots/supervisor/controllers/supervisor_emitter_receiver.py
@@ -40,6 +40,30 @@ class SupervisorEmitterReceiver(SupervisorEnv):
             self.get_info(),
         )
 
+    def reset(self):
+        """
+        Default implementation of reset method, using Webots-provided methods.
+        *Note that this works properly only with Webots versions >R2020b and must be
+        overridden with a custom reset method when using earlier versions. It is backwards compatible
+        due to the fact that the new reset method gets overridden by whatever the user has previously
+        implemented, so an old supervisor such as SupervisorCSV can be migrated easily to use this class.
+
+        :return: default implementation provided by get_default_observation() implementation
+        """
+        self.supervisor.simulationReset()
+        self.supervisor.simulationResetPhysics()
+        return self.get_default_observation()
+
+    @abstractmethod
+    def get_default_observation(self):
+        """
+        This method should be implemented to return a default/starting observation
+        that is use-case dependant. It is mainly used by the reset implementation above.
+
+        :return: list, contains default agent observation
+        """
+        pass
+
     @abstractmethod
     def handle_emitter(self, action):
         pass

--- a/deepbots/supervisor/controllers/supervisor_emitter_receiver.py
+++ b/deepbots/supervisor/controllers/supervisor_emitter_receiver.py
@@ -48,7 +48,7 @@ class SupervisorEmitterReceiver(SupervisorEnv):
         due to the fact that the new reset method gets overridden by whatever the user has previously
         implemented, so an old supervisor such as SupervisorCSV can be migrated easily to use this class.
 
-        :return: default implementation provided by get_default_observation() implementation
+        :return: default observation provided by get_default_observation() implementation
         """
         self.supervisor.simulationReset()
         self.supervisor.simulationResetPhysics()


### PR DESCRIPTION
New reset scheme requires a get_default_observation() method to be implemented. It is surely way easier for the user than implementing the whole reset thing.

The main consideration is whether it is fine as it is, or that it should be added higher up, in the SupervisorEnv class, so all classes below it can use it.
An example of what this causes is that in the new RobotSupervisor class, we are forced to have exactly the same reset/get_default_observation methods as in SupervisorEmitterReceiver, resulting in duplicate code across classes with partial implementations, one level lower than SupervisorEnv in the class hierarchy.

Closes #25 