### PR TITLE
get_default_observation fix

### DIFF
--- a/deepbots/supervisor/controllers/supervisor_env.py
+++ b/deepbots/supervisor/controllers/supervisor_env.py
@@ -85,7 +85,6 @@ class SupervisorEnv(ABC):
         self.supervisor.simulationResetPhysics()
         return self.get_default_observation()
 
-    @abstractmethod
     def get_default_observation(self):
         """
         This method should be implemented to return a default/starting observation
@@ -93,7 +92,7 @@ class SupervisorEnv(ABC):
 
         :return: list-like, contains default agent observation
         """
-        pass
+        return NotImplementedError
 
     @abstractmethod
     def get_info(self):


### PR DESCRIPTION
User should not be enforced to implement get_default_observation. `@abstractmethod` enforces implementation, so it was replaced with `return NotImplementedError`.

By enforcing implementation we also broke all backwards compatibility, in addition to requiring a user implementing a method even though it might not be used at all. When a user actually uses the new implemented `reset()` method, the `return NotImplementedError` will throw an error so the user will be forced to implement it.

Closes aidudezzz/deepworlds#13