### PR TITLE
change getEmitter/getReceiver for getDevice

### DIFF
--- a/deepbots/robots/controllers/robot_emitter_receiver.py
+++ b/deepbots/robots/controllers/robot_emitter_receiver.py
@@ -56,8 +56,8 @@ class RobotEmitterReceiver(ABC):
 
         A basic example implementation can be:
 
-        emitter = self.robot.getEmitter("emitter")
-        receiver = self.robot.getReceiver("receiver")
+        emitter = self.robot.getDevice("emitter")
+        receiver = self.robot.getDevice("receiver")
         receiver.enable(self.timestep)
         return emitter, receiver
 

--- a/deepbots/robots/controllers/robot_emitter_receiver_csv.py
+++ b/deepbots/robots/controllers/robot_emitter_receiver_csv.py
@@ -23,8 +23,8 @@ class RobotEmitterReceiverCSV(RobotEmitterReceiver):
 
         :return: emitter and receiver references
         """
-        emitter = self.robot.getEmitter("emitter")
-        receiver = self.robot.getReceiver("receiver")
+        emitter = self.robot.getDevice("emitter")
+        receiver = self.robot.getDevice("receiver")
         receiver.enable(self.timestep)
         return emitter, receiver
 

--- a/deepbots/supervisor/controllers/supervisor_emitter_receiver.py
+++ b/deepbots/supervisor/controllers/supervisor_emitter_receiver.py
@@ -22,8 +22,8 @@ class SupervisorEmitterReceiver(SupervisorEnv):
         self.initialize_comms(emitter_name, receiver_name)
 
     def initialize_comms(self, emitter_name, receiver_name):
-        self.emitter = self.supervisor.getEmitter(emitter_name)
-        self.receiver = self.supervisor.getReceiver(receiver_name)
+        self.emitter = self.supervisor.getDevice(emitter_name)
+        self.receiver = self.supervisor.getDevice(receiver_name)
         self.receiver.enable(self.timestep)
         return self.emitter, self.receiver
 


### PR DESCRIPTION
When testing my repo [deepbots-panda](https://github.com/KelvinYang0320/deepbots-panda) on Webots R2021a, there are some deprecation warnings.
DEPRECATION: Robot.getEmitter is deprecated, please use Robot.getDevice instead.
I have changed these for <code> getDevice</code> in my local deepbots package to get rid of the warning message. 