### PR TITLE
Fixed the deprecation warning

### DIFF
--- a/deepbots/supervisor/wrappers/keyboard_printer.py
+++ b/deepbots/supervisor/wrappers/keyboard_printer.py
@@ -7,7 +7,7 @@ class KeyboardPrinter(SupervisorEnv):
     def __init__(self, controller):
         self.controller = controller
         self.keyboard = Keyboard()
-        self.keyboard.enable(self.controller.get_timestep())
+        self.keyboard.enable(self.controller.timestep)
 
     def step(self, action):
         observation, reward, isDone, info = self.controller.step(action)


### PR DESCRIPTION
When using `KeyboardPrinter` in `keyboard_printer`, users will get the following warning.
![warning](https://user-images.githubusercontent.com/49781698/172851137-fe2413d6-489a-4717-b837-5c99f6b0baac.PNG)
This might confuse users.