### PR TITLE
Specified gym==0.21 and added tensorboardX to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-gym
+gym==0.21
+tensorboardX


### PR DESCRIPTION
* Gym: Fixed version due to breaking changes in 0.22
  We can do the same as [SB3](https://github.com/DLR-RM/stable-baselines3/blob/6d55a09f810bc0d7d38ad04ade92f2b720308b58/setup.py#L79).
https://github.com/aidudezzz/deepbots/blob/4aee211e96b4a29f17a509e5a7e3696167349c12/deepbots/supervisor/controllers/supervisor_env.py#L1
* TensorboardX: https://github.com/aidudezzz/deepbots/blob/4aee211e96b4a29f17a509e5a7e3696167349c12/deepbots/supervisor/wrappers/tensorboard_wrapper.py#L2